### PR TITLE
Fix lowercase Public Address bug in searchpa and retrievepa  + refactored code + added test cases

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SearchPublicAddressCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchPublicAddressCommand.java
@@ -93,7 +93,7 @@ public class SearchPublicAddressCommand extends Command {
                     publicAddressString))
                 .reduce((a, b) -> a + "\n" + b)
                 .orElse("");
-            output = String.format(message, publicAddressString.toLowerCase() + "\n" + personsDetails);
+            output = String.format(message, publicAddressString + "\n" + personsDetails);
         } else {
             String message = MESSAGE_SEARCH_PUBLIC_ADDRESS_SUCCESS_NOT_FOUND;
             output = String.format(message, publicAddressString);

--- a/src/main/java/seedu/address/model/addresses/PublicAddress.java
+++ b/src/main/java/seedu/address/model/addresses/PublicAddress.java
@@ -118,7 +118,7 @@ public abstract class PublicAddress {
      * @return String
      */
     public String getPublicAddressString() {
-        return publicAddress.toLowerCase();
+        return publicAddress;
     }
 
     /**

--- a/src/main/java/seedu/address/model/addresses/PublicAddressesComposition.java
+++ b/src/main/java/seedu/address/model/addresses/PublicAddressesComposition.java
@@ -459,7 +459,7 @@ public class PublicAddressesComposition {
                     .append(address.getLabel())
                     .append(":\n")
                     .append(INDENT + INDENT + INDENT + INDENT)
-                    .append(address.getPublicAddressString().toLowerCase())
+                    .append(address.getPublicAddressString())
                     .append("\n");
             });
         });

--- a/src/test/java/seedu/address/logic/commands/SearchPublicAddressCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchPublicAddressCommandTest.java
@@ -57,7 +57,7 @@ public class SearchPublicAddressCommandTest {
             Set.of(new SolAddress(VALID_PUBLIC_ADDRESS_SOL_SUB_STRING, "sub"))));
         String expectedMessage =
             String.format(SearchPublicAddressCommand.MESSAGE_SEARCH_PUBLIC_ADDRESS_SUCCESS_FOUND,
-                VALID_PUBLIC_ADDRESS_SOL_SUB_STRING.toLowerCase() + "\n"
+                VALID_PUBLIC_ADDRESS_SOL_SUB_STRING + "\n"
                     + secondPerson.getName() + "\n" + INDENT
                     + publicAddressesComposition.toStringIndented());
 
@@ -83,7 +83,7 @@ public class SearchPublicAddressCommandTest {
 
         String expectedMessage =
             String.format(MESSAGE_SEARCH_PUBLIC_ADDRESS_SUCCESS_FOUND,
-                VALID_PUBLIC_ADDRESS_SOL_MAIN_STRING.toLowerCase() + "\n"
+                VALID_PUBLIC_ADDRESS_SOL_MAIN_STRING + "\n"
                     + secondPerson.getName() + "\n" + INDENT
                     + publicAddressesCompositionSol.toStringIndented() + "\n"
                     + thirdPerson.getName() + "\n" + INDENT


### PR DESCRIPTION
Fixes #233 #224
Having accurately capitalized  addresses, is not merely just a UI improvement, the capitalization of public addresses contains checksum information for other systems the user may interact with to input the public addresses into, not having accurate address capitalization would result in incompatibility with other external apps which form part of the process of approving a transaction to send fund when the public address is copied from the terminal DLTbook.


How this change is not a feature compared to definition of a feature for the changes to capitalization seen here:
Before commits of this PR:
<img width="719" alt="Screenshot 2024-11-09 at 7 11 10 PM" src="https://github.com/user-attachments/assets/9e41fc93-dc18-4cda-ba76-22da3c9802bf">


After commits of this PR:
<img width="743" alt="Screenshot 2024-11-09 at 6 45 58 PM" src="https://github.com/user-attachments/assets/3c4bd6a4-2c03-4c6f-84af-eb11f2353650">


def 1. the current behavior is not strictly 'incorrect' but 'can be better'.
- Case inaccurate public addresses is incorrect as it prevents the public addresses displayed within the terminal output of our application for search and retrieve within DLTbook to be used by others, manually scrolling through 100s of public addresses and ensuring each character of the public address matches is not a prospect users will do and will wrongly trust the non capitalized public addresses.

def 2. the current behavior inconveniences the user but there is a way to work around it.
- This there is no way to work around this behavior as the users cannot guess which letters are capitalized nor does our app have the function to recalculate the checksum.

def 3. the advertised behavior was not actually implemented (or only partially implemented) in the JAR used for the PE-D.
- The actual feature was implemented but there was excess code causing this bug.


