### PR TITLE
Fix bugs regarding storing public addresses as only lowercase in storage + fix display bug in terminal if uppercase public addresses inputted for search

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SearchPublicAddressCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchPublicAddressCommand.java
@@ -43,7 +43,7 @@ public class SearchPublicAddressCommand extends Command {
         requireAllNonNull(publicAddressString);
 
 
-        this.publicAddressString = publicAddressString;
+        this.publicAddressString = publicAddressString.toLowerCase();
 
 
     }

--- a/src/main/java/seedu/address/logic/commands/SearchPublicAddressCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchPublicAddressCommand.java
@@ -33,17 +33,6 @@ public class SearchPublicAddressCommand extends Command {
     public static final String MESSAGE_SEARCH_PUBLIC_ADDRESS_SUCCESS_FOUND = "Successfully found Persons with public "
         + "address inputted: %1$s";
 
-    public static final String MESSAGE_SEARCH_PUBLIC_ADDRESS_SUBSTRING_SUCCESS = "Successfully found Persons with "
-        + "public "
-        + "address containing the substring inputted:\n%1$s";
-    public static final String MESSAGE_SEARCH_PUBLIC_ADDRESS_SUBSTRING_FAIL =
-        "Can't find any Person with public address of"
-            + " containing the "
-            + "public substring inputted:\n%1$s";
-
-
-    public static final String MESSAGE_ARGUMENTS = "Public Address: %1$s";
-
 
     private final String publicAddressString;
 

--- a/src/main/java/seedu/address/logic/parser/AddPublicAddressCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPublicAddressCommandParser.java
@@ -41,9 +41,9 @@ public class AddPublicAddressCommandParser implements Parser<AddPublicAddressCom
         requireNonNull(args);
 
         if (ArgumentTokenizer.containsExtraPrefixes(args, PREFIX_PUBLIC_ADDRESS_NETWORK, PREFIX_PUBLIC_ADDRESS_LABEL,
-                PREFIX_PUBLIC_ADDRESS)) {
+            PREFIX_PUBLIC_ADDRESS)) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPublicAddressCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPublicAddressCommand.MESSAGE_USAGE));
         }
 
         ArgumentMultimap argMultimap =
@@ -65,13 +65,16 @@ public class AddPublicAddressCommandParser implements Parser<AddPublicAddressCom
                 AddPublicAddressCommand.MESSAGE_USAGE));
         }
 
+
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PUBLIC_ADDRESS_NETWORK, PREFIX_PUBLIC_ADDRESS,
             PREFIX_PUBLIC_ADDRESS_LABEL);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
         String networkString = argMultimap.getValue(PREFIX_PUBLIC_ADDRESS_NETWORK).get();
-        String publicAddressString = argMultimap.getValue(PREFIX_PUBLIC_ADDRESS).get();
+        String publicAddressString = argMultimap.getValue(PREFIX_PUBLIC_ADDRESS).get().toLowerCase();
+
+
         String publicAddressLabelString =
             argMultimap.getValue(PREFIX_PUBLIC_ADDRESS_LABEL).get(); // okay as prefixes are confirmed to be present
 

--- a/src/main/java/seedu/address/model/addresses/PublicAddress.java
+++ b/src/main/java/seedu/address/model/addresses/PublicAddress.java
@@ -19,11 +19,11 @@ public abstract class PublicAddress {
     public static final String MESSAGE_SEARCH_PUBLIC_ADDRESS_SUCCESS_NOT_FOUND =
         "Can't find any Person with public address"
             + " inputted: %1$s";
-    public static final String MESSAGE_SEARCH_PUBLIC_ADDRESS_FAILURE_INVALID_CHAR =
+    public static final String MESSAGE_PUBLIC_ADDRESS_FAILURE_INVALID_CHAR =
         "Public Address contains only alphanumeric characters";
-    public static final String MESSAGE_SEARCH_PUBLIC_ADDRESS_FAILURE_TOO_LONG =
+    public static final String MESSAGE_PUBLIC_ADDRESS_FAILURE_TOO_LONG =
         "Public Address for length BTC/ETH/SOL should be less than 44 characters";
-    public static final String MESSAGE_SEARCH_PUBLIC_ADDRESS_FAILURE_TOO_SHORT =
+    public static final String MESSAGE_PUBLIC_ADDRESS_FAILURE_TOO_SHORT =
         "Public Address for length BTC/ETH/SOL should be more than 26 characters";
 
     public final String publicAddress;
@@ -59,11 +59,11 @@ public abstract class PublicAddress {
      */
     public static void validatePublicAddress(String publicAddress) throws IllegalArgumentException {
         if (publicAddress.length() > 44) { //length of public address too long
-            throw new IllegalArgumentException(MESSAGE_SEARCH_PUBLIC_ADDRESS_FAILURE_TOO_LONG);
+            throw new IllegalArgumentException(MESSAGE_PUBLIC_ADDRESS_FAILURE_TOO_LONG);
         } else if (!(publicAddress.matches(VALIDATION_PUBLIC_ADDRESS_REGEX))) {
-            throw new IllegalArgumentException(MESSAGE_SEARCH_PUBLIC_ADDRESS_FAILURE_INVALID_CHAR);
+            throw new IllegalArgumentException(MESSAGE_PUBLIC_ADDRESS_FAILURE_INVALID_CHAR);
         } else if (publicAddress.length() < 26) { //length of public address too short
-            throw new IllegalArgumentException(MESSAGE_SEARCH_PUBLIC_ADDRESS_FAILURE_TOO_SHORT);
+            throw new IllegalArgumentException(MESSAGE_PUBLIC_ADDRESS_FAILURE_TOO_SHORT);
         }
     }
 
@@ -118,7 +118,7 @@ public abstract class PublicAddress {
      * @return String
      */
     public String getPublicAddressString() {
-        return publicAddress.toLowerCase();
+        return publicAddress;
     }
 
     /**

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -30,11 +30,11 @@
       "publicAddresses": {
         "SOL": [
           {
-            "address": "2rB4kogqBNwCxmDXwRCNRPijV94g5udCb7Bp435fvfBA",
+            "address": "2rb4kogqbnwcxmdxwrcnrpijv94g5udcb7bp435fvfba",
             "label": "main"
           },
           {
-            "address": "44wP1ZSKZX4PDADKU2i14EyU8TsXdjZahxGNMryvv3Ty",
+            "address": "44wp1zskzx4pdadku2i14eyu8tsxdjzahxgnmryvv3ty",
             "label": "sub"
           }
         ]
@@ -52,7 +52,7 @@
       "publicAddresses": {
         "SOL": [
           {
-            "address": "2rB4kogqBNwCxmDXwRCNRPijV94g5udCb7Bp435fvfBA",
+            "address": "2rb4kogqbnwcxmdxwrcnrpijv94g5udcb7bp435fvfba",
             "label": "main"
           }
         ]

--- a/src/test/java/seedu/address/logic/commands/SearchPublicAddressCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchPublicAddressCommandTest.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.StringUtil.INDENT;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.SearchPublicAddressCommand.MESSAGE_SEARCH_PUBLIC_ADDRESS_SUCCESS_FOUND;
-import static seedu.address.model.addresses.PublicAddress.MESSAGE_SEARCH_PUBLIC_ADDRESS_FAILURE_INVALID_CHAR;
+import static seedu.address.model.addresses.PublicAddress.MESSAGE_PUBLIC_ADDRESS_FAILURE_INVALID_CHAR;
 import static seedu.address.model.addresses.PublicAddress.MESSAGE_SEARCH_PUBLIC_ADDRESS_SUCCESS_NOT_FOUND;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
@@ -57,7 +57,7 @@ public class SearchPublicAddressCommandTest {
             Set.of(new SolAddress(VALID_PUBLIC_ADDRESS_SOL_SUB_STRING, "sub"))));
         String expectedMessage =
             String.format(SearchPublicAddressCommand.MESSAGE_SEARCH_PUBLIC_ADDRESS_SUCCESS_FOUND,
-                VALID_PUBLIC_ADDRESS_SOL_SUB_STRING.toLowerCase() + "\n"
+                VALID_PUBLIC_ADDRESS_SOL_SUB_STRING + "\n"
                     + secondPerson.getName() + "\n" + INDENT
                     + publicAddressesComposition.toStringIndented());
 
@@ -83,7 +83,7 @@ public class SearchPublicAddressCommandTest {
 
         String expectedMessage =
             String.format(MESSAGE_SEARCH_PUBLIC_ADDRESS_SUCCESS_FOUND,
-                VALID_PUBLIC_ADDRESS_SOL_MAIN_STRING.toLowerCase() + "\n"
+                VALID_PUBLIC_ADDRESS_SOL_MAIN_STRING + "\n"
                     + secondPerson.getName() + "\n" + INDENT
                     + publicAddressesCompositionSol.toStringIndented() + "\n"
                     + thirdPerson.getName() + "\n" + INDENT
@@ -115,7 +115,7 @@ public class SearchPublicAddressCommandTest {
     @Test
     public void execute_searchPublicAddressOnlySpaces_failure() {
         SearchPublicAddressCommand searchPublicAddressCommand = new SearchPublicAddressCommand("   ");
-        String expectedMessage = MESSAGE_SEARCH_PUBLIC_ADDRESS_FAILURE_INVALID_CHAR;
+        String expectedMessage = MESSAGE_PUBLIC_ADDRESS_FAILURE_INVALID_CHAR;
         assertCommandFailure(searchPublicAddressCommand, model, expectedMessage);
     }
 
@@ -123,7 +123,7 @@ public class SearchPublicAddressCommandTest {
     @Test
     public void execute_searchPublicAddressWithSpaces_failure() {
         SearchPublicAddressCommand searchPublicAddressCommand = new SearchPublicAddressCommand(" abc123 ");
-        String expectedMessage = MESSAGE_SEARCH_PUBLIC_ADDRESS_FAILURE_INVALID_CHAR;
+        String expectedMessage = MESSAGE_PUBLIC_ADDRESS_FAILURE_INVALID_CHAR;
         assertCommandFailure(searchPublicAddressCommand, model, expectedMessage);
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalPublicAddresses.java
+++ b/src/test/java/seedu/address/testutil/TypicalPublicAddresses.java
@@ -11,30 +11,30 @@ import seedu.address.model.addresses.SolAddress;
  */
 public class TypicalPublicAddresses {
     public static final String VALID_PUBLIC_ADDRESS_ETH_MAIN_STRING =
-        "0x0B1C9E1Fb5E13c797c7f0134641810E9A7ca14d2"; //this is a real ETH public address
+        "0x0B1C9E1Fb5E13c797c7f0134641810E9A7ca14d2".toLowerCase(); //this is a real ETH public address
     public static final String VALID_PUBLIC_ADDRESS_ETH_SUB_STRING =
-        "0xE859Ed4267af9f247aAB2703CebcA466C71887b2"; //this is a real ETH public address
+        "0xE859Ed4267af9f247aAB2703CebcA466C71887b2".toLowerCase(); //this is a real ETH public address
     public static final String VALID_PUBLIC_ADDRESS_BTC_MAIN_STRING =
-        "bc1qak5yzzvn7va9qmkp7g5uykg2msc5kt0z0uhv2k"; //this is a real BTC public address
+        "bc1qak5yzzvn7va9qmkp7g5uykg2msc5kt0z0uhv2k".toLowerCase(); //this is a real BTC public address
     public static final String VALID_PUBLIC_ADDRESS_BTC_SUB_STRING =
-        "bc1qrcpwxgwmy7yp73eq9xmnr9t43ncl7ms8jly0tt"; //this is a real BTC public address
+        "bc1qrcpwxgwmy7yp73eq9xmnr9t43ncl7ms8jly0tt".toLowerCase(); //this is a real BTC public address
     public static final String VALID_PUBLIC_ADDRESS_BTC_COLD_STRING =
-        "bc1phkt4pgl42lad3mm2srne73y8a7zgam3cumrzmc";
+        "bc1phkt4pgl42lad3mm2srne73y8a7zgam3cumrzmc".toLowerCase();
     public static final String VALID_PUBLIC_ADDRESS_BTC_NOT_IN_ADDRESS_BOOK_BTC_STRING =
-        "bc1q5y5960gr9vnjlmwfst232z07surun7rey5svu9"; //this is a real BTC public address
+        "bc1q5y5960gr9vnjlmwfst232z07surun7rey5svu9".toLowerCase(); //this is a real BTC public address
     public static final String VALID_PUBLIC_ADDRESS_SOL_MAIN_STRING =
-        "2rB4kogqBNwCxmDXwRCNRPijV94g5udCb7Bp435fvfBA"; //this is a real SOL public address
+        "2rB4kogqBNwCxmDXwRCNRPijV94g5udCb7Bp435fvfBA".toLowerCase(); //this is a real SOL public address
     public static final String VALID_PUBLIC_ADDRESS_SOL_SUB_STRING =
-        "44wP1ZSKZX4PDADKU2i14EyU8TsXdjZahxGNMryvv3Ty"; //this is a real SOL public address
+        "44wP1ZSKZX4PDADKU2i14EyU8TsXdjZahxGNMryvv3Ty".toLowerCase(); //this is a real SOL public address
     //ETH PA length 42
     //SOL PA length 32-44
     //BTC PA length 26-35
     //testing purposes
     public static final String INVALID_PUBLIC_ADDRESS_INVALID_CHAR_STRING = "0x!@#$%^&*()";
     public static final String INVALID_PUBLIC_ADDRESS_TOO_LONG_STRING =
-        "0x0B1C9E1Fb5Ec797c7f0134641810E9A7ca14d2wjrenlkewrngilsdfjdshfsdkfewrkhgnilwerkngiwrengiwrhngirwengiwrengiwer";
-    public static final String VALID_PUBLIC_ADDRESS_ONLY_NUMBERS_STRING = "0123456789012345678901234567890123456789";
-    public static final String VALID_PUBLIC_ADDRESS_ONLY_CHARS_STRING = "0123456789abcdef0123456789abcdef01234567";
+        "0x0B1C9E1Fb5Ec797c7f0134641810E9A7ca14d2wjrenlkewrngilsdfjdshfsdkfewrkhgnilwerkngiwrengiwrhngirwengiwrengiwer".toLowerCase();
+    public static final String VALID_PUBLIC_ADDRESS_ONLY_NUMBERS_STRING = "0123456789012345678901234567890123456789".toLowerCase();
+    public static final String VALID_PUBLIC_ADDRESS_ONLY_CHARS_STRING = "0123456789abcdef0123456789abcdef01234567".toLowerCase();
 
     public static final PublicAddress VALID_PUBLIC_ADDRESS_ETH_MAIN =
         new EthAddress(VALID_PUBLIC_ADDRESS_ETH_MAIN_STRING, "main");

--- a/src/test/java/seedu/address/testutil/TypicalPublicAddresses.java
+++ b/src/test/java/seedu/address/testutil/TypicalPublicAddresses.java
@@ -32,9 +32,12 @@ public class TypicalPublicAddresses {
     //testing purposes
     public static final String INVALID_PUBLIC_ADDRESS_INVALID_CHAR_STRING = "0x!@#$%^&*()";
     public static final String INVALID_PUBLIC_ADDRESS_TOO_LONG_STRING =
-        "0x0B1C9E1Fb5Ec797c7f0134641810E9A7ca14d2wjrenlkewrngilsdfjdshfsdkfewrkhgnilwerkngiwrengiwrhngirwengiwrengiwer".toLowerCase();
-    public static final String VALID_PUBLIC_ADDRESS_ONLY_NUMBERS_STRING = "0123456789012345678901234567890123456789".toLowerCase();
-    public static final String VALID_PUBLIC_ADDRESS_ONLY_CHARS_STRING = "0123456789abcdef0123456789abcdef01234567".toLowerCase();
+        "0x0B1C9E1Fb5Ec797c7f0134641810E9A7ca14d2wjrenlkewrngilsdfjdshfsdkfewrkhgnilwerkngiwrengiwrhngirwengiwrengiwer"
+            .toLowerCase();
+    public static final String VALID_PUBLIC_ADDRESS_ONLY_NUMBERS_STRING =
+        "0123456789012345678901234567890123456789".toLowerCase();
+    public static final String VALID_PUBLIC_ADDRESS_ONLY_CHARS_STRING = "0123456789abcdef0123456789abcdef01234567"
+        .toLowerCase();
 
     public static final PublicAddress VALID_PUBLIC_ADDRESS_ETH_MAIN =
         new EthAddress(VALID_PUBLIC_ADDRESS_ETH_MAIN_STRING, "main");


### PR DESCRIPTION
Fixes #224 and #224 #217
why setting public address in storage to be only lower case is allowed?
- addpa should have added public addresses and stored it as lowercase as described in UG but it was not done
<img width="849" alt="Screenshot 2024-11-10 at 12 32 49 AM" src="https://github.com/user-attachments/assets/ae79aebe-52dd-4f6e-af30-b7ac2923806e">
<img width="573" alt="Screenshot 2024-11-10 at 12 34 16 AM" src="https://github.com/user-attachments/assets/685a5146-04b9-4f84-8a2a-c9ea162cf019">


why fixing display error in terminal if uppercase public address inputted for searchpa allowed?
Actual behavior of output of searchPublicAddress is to display contact and wallet as specified in UG but only contact was displayed
<img width="803" alt="Screenshot 2024-11-10 at 12 36 15 AM" src="https://github.com/user-attachments/assets/3eb3d75b-6a8f-48dd-8eca-a2083f29923d">
<img width="906" alt="Screenshot 2024-11-10 at 12 53 25 AM" src="https://github.com/user-attachments/assets/00fd7cf0-ecc8-4ca0-8574-69b352f26853">
<img width="739" alt="Screenshot 2024-11-10 at 12 56 29 AM" src="https://github.com/user-attachments/assets/956f1d5e-7b1e-4858-a490-3c2a1f12ceb4">
<img width="736" alt="Screenshot 2024-11-10 at 12 55 50 AM" src="https://github.com/user-attachments/assets/5556af0d-721b-4d85-afe7-bdd729c1fd36">


why search pa input is case insentitive

<img width="514" alt="Screenshot 2024-11-10 at 3 12 48 PM" src="https://github.com/user-attachments/assets/5da2efbc-ec1a-4aac-99f5-8dbbb5afb8b8">

