### PR TITLE
Fix deletepa to correctly delete with case insensitive labels

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -538,9 +538,6 @@ Format: `deletepa INDEX c/NETWORK [l/WALLET_NAME]`
   that will be deleted. If `WALLET_NAME` is not provided, all public addresses in the `NETWORK` of the person 
   at the specified `INDEX` will be deleted. This field is **case-insensitive**.
 
-* The Wallet Name is Case-sensitive. It will not work unless the Wallet Name is exactly the same as the one in the
-  contact.
-
 Examples:
 
 

--- a/src/main/java/seedu/address/model/addresses/PublicAddressesComposition.java
+++ b/src/main/java/seedu/address/model/addresses/PublicAddressesComposition.java
@@ -442,7 +442,7 @@ public class PublicAddressesComposition {
         if (networkAddresses != null) {
             // Remove the address with matching label
             Set<PublicAddress> updatedAddresses = networkAddresses.stream()
-                .filter(addr -> !addr.label.equals(label))
+                .filter(addr -> !addr.label.equalsIgnoreCase(label))
                 .collect(Collectors.toSet());
 
             // If set is empty after removal, remove the network entirely


### PR DESCRIPTION
Fixes #261 

UG claims that public address label is **case-insensitive** but when trying to delete an existing label L_CURRENT with label L_INPUT such that L_CURRENT  and L_INPUT made of the same characters in different cases, the resulting message incorrectly shows that the public address (and label) has been deleted, which does not actually happen.

E.g. L_CURRENT = "WALLET", L_INPUT = "wallet". Then the result message shows that the deletion happened, but the record is not actually deleted.

This is a clear bug because there is a discrepancy between what is to be expected by the user, and what actually happens.