### PR TITLE
Update duplicate-label-message to fit within feature freeze requirements

### DIFF
--- a/src/main/java/seedu/address/model/addresses/PublicAddressesComposition.java
+++ b/src/main/java/seedu/address/model/addresses/PublicAddressesComposition.java
@@ -29,7 +29,8 @@ public class PublicAddressesComposition {
     public static final String MESSAGE_DUPLICATE_LABEL =
         "Label %1$s under the network %2$s already exists.";
 
-    public static final String MESSAGE_DUPLICATE_PUBLIC_ADDRESS = "Invalid: duplicate label or public address\n%1$s\n";
+    public static final String MESSAGE_DUPLICATE_PUBLIC_ADDRESS = "Invalid: %1$s\n"
+        + INDENT + "duplicate label or public address";
 
     private final Map<Network, Set<PublicAddress>> publicAddresses;
 


### PR DESCRIPTION
Update message shown when duplicate labels are input to be a more general extension of the previous version (to include duplicate public address), while keeping the same visuals. Fixes feature-freeze break caused by #272 

Before: (#272)

![image](https://github.com/user-attachments/assets/e20927d8-93a7-4527-ba6e-1a16254dba8c)

Original (before feature freeze):

![image](https://github.com/user-attachments/assets/97334989-e0c6-4bf9-be15-c5bcf291f132)

After:

![image](https://github.com/user-attachments/assets/3029a35d-6bc5-4690-9dc7-5ca3c1511837)


I.e. "After" is closer to "Original" than "Before"